### PR TITLE
demote wallet from primary nav and home page CTA

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -17,21 +17,17 @@ export default async function DashboardLayout({
       <nav className="bg-gray-950 border-b border-green-900">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between h-16">
-            <div className="flex items-center space-x-8 font-mono">
+            <div className="flex items-center font-mono">
               <a href="/" className="text-green-400 font-bold">
                 $ agentmarketplace
               </a>
+            </div>
+            <div className="flex items-center font-mono">
               <a
                 href="/wallet"
-                className="text-gray-400 hover:text-green-400 text-sm"
+                className="text-gray-600 hover:text-gray-400 text-xs"
               >
                 wallet
-              </a>
-              <a
-                href="/workers"
-                className="text-gray-400 hover:text-green-400 text-sm"
-              >
-                workers
               </a>
             </div>
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -104,19 +104,14 @@ export default function HomePage() {
                 <span className="text-green-400">✓</span>
                 <div>
                   <p className="font-semibold text-green-400">Signed in</p>
-                  <p className="text-gray-400 text-sm">Skills + paid agents unlocked</p>
+                  <p className="text-gray-400 text-sm">You're all set — run skills from your terminal.</p>
                 </div>
               </div>
               <UserButton />
             </div>
-            <div className="mt-4 flex space-x-3">
-              <Link
-                href="/wallet"
-                className="inline-block px-4 py-2 border border-green-700 text-green-400 rounded hover:bg-gray-800 text-sm font-medium"
-              >
-                → wallet
-              </Link>
-            </div>
+            <p className="mt-3 text-xs text-gray-600">
+              <Link href="/wallet" className="hover:text-gray-400">manage wallet →</Link>
+            </p>
           </SignedIn>
         </div>
       </div>

--- a/features/payments/wallet.ts
+++ b/features/payments/wallet.ts
@@ -103,8 +103,9 @@ export class WalletService {
 
         const currentBalance = parseFloat(user.walletBalance);
         if (currentBalance < amount) {
+          const shortfall = amount - currentBalance;
           throw new Error(
-            `Insufficient funds. Balance: $${currentBalance.toFixed(2)}, Required: $${amount.toFixed(2)}`
+            `Insufficient funds. Balance: $${currentBalance.toFixed(2)}, Required: $${amount.toFixed(2)} (short $${shortfall.toFixed(2)}). Add funds at ${process.env.NEXT_PUBLIC_APP_URL}/wallet`
           );
         }
 

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -399,6 +399,24 @@ class MentatServer {
 
     const { balance, needsTopUp } = await response.json();
 
+    if (balance === 0) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: [
+              `Wallet Balance: $0.00`,
+              ``,
+              `All skills are free — no wallet funding needed.`,
+              `You'll only need to add funds when paid workers become available.`,
+              ``,
+              `Top up anytime at: ${API_BASE_URL}/wallet`,
+            ].join('\n'),
+          },
+        ],
+      };
+    }
+
     return {
       content: [
         {


### PR DESCRIPTION
wallet is only needed for future paid workers — no reason to put it front and center when only free skills exist today. moves it to a subtle utility link and makes the MCP check_wallet response helpful instead of a dead-end when balance is $0.